### PR TITLE
Decoupled FRI and PCS prover/verifier

### DIFF
--- a/crates/prover/src/core/pcs/mod.rs
+++ b/crates/prover/src/core/pcs/mod.rs
@@ -11,6 +11,16 @@ pub mod quotients;
 mod utils;
 mod verifier;
 
+use crate::core::backend::Backend;
+use crate::core::channel::Blake2sChannel;
+use crate::core::circle::CirclePoint;
+use crate::core::ColumnVec;
+use crate::core::fields::qm31::SecureField;
+use crate::core::fri::{FriConfig, FriOps, FriProof};
+use crate::core::poly::circle::PolyOps;
+use crate::core::prover::{VerificationError, LOG_BLOWUP_FACTOR, LOG_LAST_LAYER_DEGREE_BOUND, N_QUERIES};
+use crate::core::vcs::blake2_merkle::Blake2sMerkleHasher;
+use crate::core::vcs::ops::{MerkleHasher, MerkleOps};
 pub use self::prover::{CommitmentSchemeProof, CommitmentSchemeProver, CommitmentTreeProver};
 pub use self::utils::TreeVec;
 pub use self::verifier::CommitmentSchemeVerifier;
@@ -20,4 +30,55 @@ pub struct TreeColumnSpan {
     pub tree_index: usize,
     pub col_start: usize,
     pub col_end: usize,
+}
+
+pub trait PolynomialCommitmentSchemeBase {
+    type Config;
+    type Proof;
+    type Channel;
+
+    fn config() -> Self::Config;
+}
+
+pub trait PolynomialCommitmentScheme<B: PolyOps, H: MerkleHasher>: PolynomialCommitmentSchemeBase {
+    type Prover<'a>: PolynomialProver<Self::Channel, Self::Proof> where B: 'a;
+    type Verifier: PolynomialVerifier<Self::Channel, Self::Proof>;
+}
+
+pub trait PolynomialProver<Channel, Proof> {
+    fn prove_values(
+        &self,
+        sampled_points: TreeVec<ColumnVec<Vec<CirclePoint<SecureField>>>>,
+        channel: &mut Channel,
+    ) -> CommitmentSchemeProof<Proof>;
+}
+
+pub trait PolynomialVerifier<Channel, Proof>: Sized {
+    fn verify_values(
+        &self,
+        sampled_points: TreeVec<ColumnVec<Vec<CirclePoint<SecureField>>>>,
+        proof: CommitmentSchemeProof<Proof>,
+        channel: &mut Channel,
+    ) -> Result<(), VerificationError>;
+}
+
+// TODO(alex): Move to a submodule
+pub struct FriCommitmentScheme;
+
+impl PolynomialCommitmentSchemeBase for FriCommitmentScheme {
+    type Config = FriConfig;
+    type Proof = FriProof<Blake2sMerkleHasher>;
+    type Channel = Blake2sChannel;
+
+    fn config() -> FriConfig {
+        FriConfig::new(LOG_LAST_LAYER_DEGREE_BOUND, LOG_BLOWUP_FACTOR, N_QUERIES)
+    }
+}
+
+impl<B> PolynomialCommitmentScheme<B, Blake2sMerkleHasher> for FriCommitmentScheme
+where
+    B: Backend + FriOps + MerkleOps<Blake2sMerkleHasher>,
+{
+    type Prover<'a> = CommitmentSchemeProver<'a, B, Self::Proof> where B: 'a;
+    type Verifier = CommitmentSchemeVerifier<Self::Proof>;
 }

--- a/crates/prover/src/core/pcs/mod.rs
+++ b/crates/prover/src/core/pcs/mod.rs
@@ -20,7 +20,7 @@ use crate::core::fri::{FriConfig, FriOps, FriProof};
 use crate::core::poly::circle::PolyOps;
 use crate::core::prover::{VerificationError, LOG_BLOWUP_FACTOR, LOG_LAST_LAYER_DEGREE_BOUND, N_QUERIES};
 use crate::core::vcs::blake2_merkle::Blake2sMerkleHasher;
-use crate::core::vcs::ops::{MerkleHasher, MerkleOps};
+use crate::core::vcs::ops::MerkleOps;
 pub use self::prover::{CommitmentSchemeProof, CommitmentSchemeProver, CommitmentTreeProver};
 pub use self::utils::TreeVec;
 pub use self::verifier::CommitmentSchemeVerifier;
@@ -40,7 +40,7 @@ pub trait PolynomialCommitmentSchemeBase {
     fn config() -> Self::Config;
 }
 
-pub trait PolynomialCommitmentScheme<B: PolyOps, H: MerkleHasher>: PolynomialCommitmentSchemeBase {
+pub trait PolynomialCommitmentScheme<B: PolyOps>: PolynomialCommitmentSchemeBase {
     type Prover<'a>: PolynomialProver<Self::Channel, Self::Proof> where B: 'a;
     type Verifier: PolynomialVerifier<Self::Channel, Self::Proof>;
 }
@@ -75,7 +75,7 @@ impl PolynomialCommitmentSchemeBase for FriCommitmentScheme {
     }
 }
 
-impl<B> PolynomialCommitmentScheme<B, Blake2sMerkleHasher> for FriCommitmentScheme
+impl<B> PolynomialCommitmentScheme<B> for FriCommitmentScheme
 where
     B: Backend + FriOps + MerkleOps<Blake2sMerkleHasher>,
 {

--- a/crates/prover/src/examples/fibonacci/mod.rs
+++ b/crates/prover/src/examples/fibonacci/mod.rs
@@ -14,19 +14,16 @@ use crate::core::poly::circle::{CanonicCoset, CircleEvaluation};
 use crate::core::poly::BitReversedOrder;
 use crate::core::prover::{ProvingError, StarkProof, VerificationError};
 use crate::core::vcs::blake2_hash::Blake2sHasher;
-use crate::core::vcs::blake2_merkle::Blake2sMerkleHasher;
 use crate::core::vcs::hasher::Hasher;
 use crate::trace_generation::{commit_and_prove, commit_and_verify};
 
 pub mod air;
 mod component;
 
-type MerkleHasher = Blake2sMerkleHasher;
-
 #[derive(Clone)]
 pub struct Fibonacci<Pcs>
 where
-    Pcs: PolynomialCommitmentScheme<CpuBackend, MerkleHasher>,
+    Pcs: PolynomialCommitmentScheme<CpuBackend>,
 {
     pub air: FibonacciAir,
     _phantom_pcs: PhantomData<Pcs>,
@@ -34,7 +31,7 @@ where
 
 impl<Pcs> Fibonacci<Pcs>
 where
-    Pcs: PolynomialCommitmentScheme<CpuBackend, MerkleHasher, Channel = Blake2sChannel>,
+    Pcs: PolynomialCommitmentScheme<CpuBackend, Channel = Blake2sChannel>,
     for<'a> CommitmentSchemeProver<'a, CpuBackend, Pcs::Proof>: PolynomialProver<Pcs::Channel, Pcs::Proof>,
     CommitmentSchemeVerifier<Pcs::Proof>: PolynomialVerifier<Pcs::Channel, Pcs::Proof>,
 {
@@ -85,7 +82,7 @@ where
 
 pub struct MultiFibonacci<Pcs>
 where
-    Pcs: PolynomialCommitmentScheme<CpuBackend, MerkleHasher>,
+    Pcs: PolynomialCommitmentScheme<CpuBackend>,
 {
     pub air: MultiFibonacciAir,
     log_sizes: Vec<u32>,
@@ -95,7 +92,7 @@ where
 
 impl<Pcs> MultiFibonacci<Pcs>
 where
-    Pcs: PolynomialCommitmentScheme<CpuBackend, MerkleHasher, Channel = Blake2sChannel>,
+    Pcs: PolynomialCommitmentScheme<CpuBackend, Channel = Blake2sChannel>,
     for<'a> CommitmentSchemeProver<'a, CpuBackend, Pcs::Proof>: PolynomialProver<Pcs::Channel, Pcs::Proof>,
     CommitmentSchemeVerifier<Pcs::Proof>: PolynomialVerifier<Pcs::Channel, Pcs::Proof>,
 {

--- a/crates/prover/src/examples/wide_fibonacci/mod.rs
+++ b/crates/prover/src/examples/wide_fibonacci/mod.rs
@@ -234,7 +234,7 @@ mod tests {
         let air = WideFibAir { component };
         let prover_channel =
             &mut Blake2sChannel::new(Blake2sHasher::hash(BaseField::into_slice(&[])));
-        let proof = commit_and_prove::<CpuBackend>(&air, prover_channel, trace).unwrap();
+        let proof = commit_and_prove::<CpuBackend, _>(&air, prover_channel, trace).unwrap();
 
         let verifier_channel =
             &mut Blake2sChannel::new(Blake2sHasher::hash(BaseField::into_slice(&[])));

--- a/crates/prover/src/examples/wide_fibonacci/simd.rs
+++ b/crates/prover/src/examples/wide_fibonacci/simd.rs
@@ -287,7 +287,7 @@ mod tests {
         span.exit();
         let channel = &mut Blake2sChannel::new(Blake2sHasher::hash(BaseField::into_slice(&[])));
         let air = SimdWideFibAir { component };
-        let proof = commit_and_prove::<SimdBackend>(&air, channel, trace).unwrap();
+        let proof = commit_and_prove::<SimdBackend, _>(&air, channel, trace).unwrap();
 
         let channel = &mut Blake2sChannel::new(Blake2sHasher::hash(BaseField::into_slice(&[])));
         commit_and_verify(proof, &air, channel).unwrap();


### PR DESCRIPTION
In the original Stwo code, polynomial commitment scheme is hardcoded to be FRI, with only the backend up for a change.
Since we're planning to integrate circleSTIR, I've decoupled FRI from the general PCS through.
Some FRI-specific code is still spread across different modules (I hope to clean it up a bit as I integrate circleSTIR), we now only need to provide `PolynomialCommitmentScheme` with `PolynomialProver` and `PolynomialVerifier` implementations to make a PCS work.
I'm not 100% sure this framework will be able to completely fit both FRI and STIR, but this should make things much easier and minimize changes needed in future.